### PR TITLE
Fix error font size on desktop

### DIFF
--- a/lib/views/desktop/send/widgets/DTErrorUI.dart
+++ b/lib/views/desktop/send/widgets/DTErrorUI.dart
@@ -57,8 +57,8 @@ class DTErrorUI extends StatelessWidget {
               isVisible: error != '',
               textAlign: TextAlign.center,
               textStyle: TextStyle(
-                fontSize: 20.0.sp,
-                fontFamily: Theme.of(context).textTheme.headline1?.fontFamily,
+                fontSize: 17.0,
+                fontFamily: COURIER,
                 color: Theme.of(context).textTheme.headline1?.color,
               )),
           ExtensiveDesktopErrorExpandable(


### PR DESCRIPTION
Fix error text font size on desktop to match Desktop Design guidance. (Also text was too small and scaling depending on windows scale)
---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
