### PR TITLE
Set current version defined by version number and build number in main build file

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 16.0.0
+version: 1.0.1+30
 
 environment:
   sdk: ">=2.12.0 <3.4.0"


### PR DESCRIPTION
This should allow the downstream F-Droid build to pick up the current version numbers.
---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
