### PR TITLE
Spread version code by ABI for F-Droid inclusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         run: "flutter config --enable-linux-desktop"
 
       - name: "Install linux build dependencies"
-        run: "sudo apt update && sudo apt install ninja-build libgtk-3-dev libgtkmm-3.0-dev"
+        run: "sudo apt update && sudo apt install ninja-build libgtk-3-dev libgtkmm-3.0-dev libfuse2"
 
       - name: "Build for linux"
         run: "flutter build linux lib/main_la.dart -v --dart-define version=${{ env.DESTINY_VERSION }}"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,6 +38,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+import com.android.build.OutputFile
+
 android {
     compileSdkVersion 31
 
@@ -76,9 +78,15 @@ android {
                 // Recommended by Google Play Store for testing
                 // https://developer.android.com/reference/tools/gradle-api/6.7/com/android/build/api/dsl/Ndk
                 debugSymbolLevel 'SYMBOL_TABLE'
-                // Flutter doesn't support x86, so we need add only supported platforms: https://docs.flutter.dev/deployment/android#what-are-the-supported-target-architectures
-                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
             }
+        }
+    }
+
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2, x86: 3, x86_64: 4]
+            def abiCode = abiCodes.get(output.getFilter(OutputFile.ABI))
+            output.versionCodeOverride = variant.versionCode * 10 + (abiCode != null ? abiCode : 0)
         }
     }
 }


### PR DESCRIPTION
F-Droid inclusion requires us to deliver separate APKs per ABI. This change for the Android part will help to generate separate version codes for each of these.

The app bundle we use for releases on Google Play should not be affected by this change.

In addition, the Linux build has been fixed by adding the `libfuse2` dependency to the Linux build.

---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
