### PR TITLE
Add wakelock to prevent cancelling downloads

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -52,6 +52,8 @@ PODS:
   - SwiftyGif (5.4.3)
   - url_launcher_ios (0.0.1):
     - Flutter
+  - wakelock (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - dart_wormhole_william (from `.symlinks/plugins/dart_wormhole_william/ios`)
@@ -63,6 +65,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - wakelock (from `.symlinks/plugins/wakelock/ios`)
 
 SPEC REPOS:
   trunk:
@@ -90,6 +93,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  wakelock:
+    :path: ".symlinks/plugins/wakelock/ios"
 
 SPEC CHECKSUMS:
   dart_wormhole_william: a270e984f928b2f98692a275a1a01e315c666a1c
@@ -105,6 +110,7 @@ SPEC CHECKSUMS:
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   SwiftyGif: 6c3eafd0ce693cad58bb63d2b2fb9bacb8552780
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
+  wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
 
 PODFILE CHECKSUM: ebb697cb00de69f8b4e137be7ad492233358ffad
 

--- a/lib/views/shared/receive.dart
+++ b/lib/views/shared/receive.dart
@@ -13,6 +13,7 @@ import 'package:file_picker/file_picker.dart' as f;
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wakelock/wakelock.dart';
 
 import '../../main.dart';
 import '../../settings.dart';
@@ -315,10 +316,22 @@ class ReceiveSharedState extends ChangeNotifier {
       case ReceiveScreenStates.Initial:
         return enterCodeUI();
       case ReceiveScreenStates.ReceiveError:
+        // Disable Android and iOS screens if failure
+        if (dartIO.Platform.isAndroid || dartIO.Platform.isIOS) {
+          Wakelock.disable();
+        }
         return receiveError();
       case ReceiveScreenStates.ReceiveConfirmation:
+        // Keep Android and iOS screens awake after entering code generation till success or failure
+        if (dartIO.Platform.isAndroid || dartIO.Platform.isIOS) {
+          Wakelock.enable();
+        }
         return receiveConfirmation();
       case ReceiveScreenStates.FileReceived:
+        // Disable Android and iOS screens if failure
+        if (dartIO.Platform.isAndroid || dartIO.Platform.isIOS) {
+          Wakelock.disable();
+        }
         return receivingDone();
       case ReceiveScreenStates.FileReceiving:
         return receiveProgress();

--- a/lib/views/shared/send.dart
+++ b/lib/views/shared/send.dart
@@ -10,6 +10,7 @@ import 'package:destiny/views/shared/file_picker.dart';
 import 'package:destiny/views/shared/progress.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:wakelock/wakelock.dart';
 
 import '../../main.dart';
 import '../../settings.dart';
@@ -192,14 +193,27 @@ class SendSharedState extends ChangeNotifier {
         return selectAFileUI();
 
       case SendScreenStates.FileSent:
+        // Disable Android and iOS screens if success
+        if (Platform.isAndroid || Platform.isIOS) {
+          Wakelock.disable();
+        }
+        Wakelock.disable();
         return sendingDone();
 
       case SendScreenStates.SendError:
+        // Disable Android and iOS screens if failure
+        if (Platform.isAndroid || Platform.isIOS) {
+          Wakelock.disable();
+        }
         return sendingError();
       case SendScreenStates.FileSending:
         return sendingProgress();
       case SendScreenStates.CodeGenerating:
       case SendScreenStates.CodeGenerated:
+        // Keep Android and iOS screens awake after code generation till success or failure
+        if (Platform.isAndroid || Platform.isIOS) {
+          Wakelock.enable();
+        }
         return generateCodeUI();
     }
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import package_info_plus
 import path_provider_macos
 import shared_preferences_macos
 import url_launcher_macos
+import wakelock_macos
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -20,5 +21,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WakelockMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockMacosPlugin"))
   WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -908,6 +908,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "9.0.0"
+  wakelock:
+    dependency: "direct main"
+    description:
+      name: wakelock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2"
+  wakelock_macos:
+    dependency: transitive
+    description:
+      name: wakelock_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  wakelock_web:
+    dependency: transitive
+    description:
+      name: wakelock_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_windows:
+    dependency: transitive
+    description:
+      name: wakelock_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   provider: ^6.0.0
   url_launcher: ^6.1.5
   tuple: ^2.0.1
+  wakelock: ^0.6.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added [wakelock](https://pub.dev/packages/wakelock) plugin, which prevents screen timeout during the transfer or while waiting to enter code.

Wake lock is enabled only when code is generated or entered and disabled when done or error cases.

This was added, after I jumped on issue, when on iOS device, transfers gets cancelled, after phone screens turn off, which by default 30sec - 1 min. This prevents bigger files sending (or when you have slow network) and you have manually set always on screen in order to send something.

I have not seen issue on Android phone, however there are many version of Android phone manufactures, I guess this can also be issue for Android too in some cases. Not sure if we need this for Desktop version as during testing, I have not jumped on such issues.

Manually tested with iOS and Android.
---

## Code Review Checklist

- [x] Description accurately reflects what changes are being made.
- [x] Description explains why the changes are being made (or references an issue containing one).
- [x] The PR appropriately sized.
- [ ] New code has enough tests. 
- [x] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [x] Existing documentation is up-to-date, if impacted.
