### PR TITLE
Fix missing abi filter configuration #224

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,6 +78,7 @@ android {
                 // Recommended by Google Play Store for testing
                 // https://developer.android.com/reference/tools/gradle-api/6.7/com/android/build/api/dsl/Ndk
                 debugSymbolLevel 'SYMBOL_TABLE'
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86_64'
             }
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-AndroidProject.signing=/Users/donataspuidokas/key.properties
+AndroidProject.signing=./key.properties
  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.3+31
+version: 1.0.3+34
 
 environment:
   sdk: ">=2.12.0 <3.4.0"


### PR DESCRIPTION
In addition we now have a generic signing configuration. The file `key.properties` needs to go into `android/`.
---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
