### PR TITLE
Fix stable flutter version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,15 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
+      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
-        uses: "subosito/flutter-action@v2.4.0"
+        uses: subosito/flutter-action@v2
+        with:
+          # set fixed stable version, to avoid surprises, when flutter upgrades
+          flutter-version: '3.3.10'
+          channel: 'stable'
+        
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"
@@ -162,8 +169,15 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
+      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
-        uses: "subosito/flutter-action@v2.4.0"
+        uses: subosito/flutter-action@v2
+        with:
+          # set fixed stable version, to avoid surprises, when flutter upgrades
+          flutter-version: '3.3.10'
+          channel: 'stable'
+        
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"
@@ -220,8 +234,15 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
+      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
-        uses: "subosito/flutter-action@v2.4.0"
+        uses: subosito/flutter-action@v2
+        with:
+          # set fixed stable version, to avoid surprises, when flutter upgrades
+          flutter-version: '3.3.10'
+          channel: 'stable'
+        
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"
@@ -256,8 +277,15 @@ jobs:
         run: 'echo "DESTINY_VERSION=${{ github.head_ref }}" >> $env:GITHUB_ENV'
         if: ${{ github.ref_type != 'tag' }}
 
+      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
-        uses: "subosito/flutter-action@v2.4.0"
+        uses: subosito/flutter-action@v2
+        with:
+          # set fixed stable version, to avoid surprises, when flutter upgrades
+          flutter-version: '3.3.10'
+          channel: 'stable'
+        
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
       # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
-          with:
-            # set fixed stable version, to avoid surprises, when flutter upgrades
-            flutter-version: '3.3.10'
-            channel: 'stable'
-      - run: flutter --version
+        with:
+          # set fixed stable version, to avoid surprises, when flutter upgrades
+          flutter-version: '3.3.10'
+          channel: 'stable'
+        run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - "main"
+      
+# https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
+env:
+  FLUTTER_VERSION: "3.3.10"
+  FLUTTER_BRANCH: "stable"
 
 jobs:
   android:
@@ -26,13 +31,12 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
-      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: '3.3.10'
-          channel: 'stable'
+          flutter-version: $FLUTTER_VERSION
+          channel: $FLUTTER_BRANCH
         
       - run: flutter --version
 
@@ -84,13 +88,12 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
-      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: '3.3.10'
-          channel: 'stable'
+          flutter-version: $FLUTTER_VERSION
+          channel: $FLUTTER_BRANCH
         
       - run: flutter --version
 
@@ -169,13 +172,12 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
-      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: '3.3.10'
-          channel: 'stable'
+          flutter-version: $FLUTTER_VERSION
+          channel: $FLUTTER_BRANCH
         
       - run: flutter --version
 
@@ -234,13 +236,12 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
-      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: '3.3.10'
-          channel: 'stable'
+          flutter-version: $FLUTTER_VERSION
+          channel: $FLUTTER_BRANCH
         
       - run: flutter --version
 
@@ -277,13 +278,12 @@ jobs:
         run: 'echo "DESTINY_VERSION=${{ github.head_ref }}" >> $env:GITHUB_ENV'
         if: ${{ github.ref_type != 'tag' }}
 
-      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: '3.3.10'
-          channel: 'stable'
+          flutter-version: $FLUTTER_VERSION
+          channel: $FLUTTER_BRANCH
         
       - run: flutter --version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - "main"
-      
+
 # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
 env:
   FLUTTER_VERSION: "3.3.10"
@@ -35,8 +35,8 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: $FLUTTER_VERSION
-          channel: $FLUTTER_BRANCH
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_BRANCH }}
         
       - run: flutter --version
 
@@ -92,8 +92,8 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: $FLUTTER_VERSION
-          channel: $FLUTTER_BRANCH
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_BRANCH }}
         
       - run: flutter --version
 
@@ -176,8 +176,8 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: $FLUTTER_VERSION
-          channel: $FLUTTER_BRANCH
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_BRANCH }}
         
       - run: flutter --version
 
@@ -240,8 +240,8 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: $FLUTTER_VERSION
-          channel: $FLUTTER_BRANCH
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_BRANCH }}
         
       - run: flutter --version
 
@@ -282,8 +282,8 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # set fixed stable version, to avoid surprises, when flutter upgrades
-          flutter-version: $FLUTTER_VERSION
-          channel: $FLUTTER_BRANCH
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_BRANCH }}
         
       - run: flutter --version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,14 @@ jobs:
         run: echo DESTINY_VERSION=${{ github.head_ref }} >> $GITHUB_ENV
         if: ${{ github.ref_type != 'tag' }}
 
+      # https://docs.flutter.dev/development/tools/sdk/releases?tab=linux
       - name: "Setup flutter"
-        uses: "subosito/flutter-action@v2.4.0"
+        uses: subosito/flutter-action@v2
+          with:
+            # set fixed stable version, to avoid surprises, when flutter upgrades
+            flutter-version: '3.3.10'
+            channel: 'stable'
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
           # set fixed stable version, to avoid surprises, when flutter upgrades
           flutter-version: '3.3.10'
           channel: 'stable'
-        run: flutter --version
+        
+      - run: flutter --version
 
       - name: "Fetch flutter dependencies"
         run: "flutter pub get"


### PR DESCRIPTION
Add fixed stable version for flutter in CI to avoid new version surprises.

Currently with flutter version 3.7.0 fails on CI: https://github.com/LeastAuthority/destiny/actions/runs/4003941775
and we have issue for that: https://github.com/LeastAuthority/destiny/issues/226

---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
